### PR TITLE
Multi-line support using jq

### DIFF
--- a/translate.sh
+++ b/translate.sh
@@ -57,5 +57,7 @@ ua='Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) C
 url="https://translate.googleapis.com/translate_a/single?client=gtx&sl=${FROM_LNG}&tl=${TO_LNG}&dt=t&q=${qry}" # Google Translate url
 # Send encoded text and language to google translate api
 response=$(curl --tr-encoding  -sA "${ua}" "${url}")
-# Print only first translation from JSON
+# The first element in response contains arrays that contain the full
+# translation in first element and and the sentences that were translated
+# in the second element. Here we get the first elements and join with a space.
 echo "${response}" | jq -cr '.[0] | map(.[0]) | join(" ")'

--- a/translate.sh
+++ b/translate.sh
@@ -58,5 +58,4 @@ url="https://translate.googleapis.com/translate_a/single?client=gtx&sl=${FROM_LN
 # Send encoded text and language to google translate api
 response=$(curl --tr-encoding  -sA "${ua}" "${url}")
 # Print only first translation from JSON
-translated=$(echo "${response}" | sed 's/","/\n/g' | sed -E 's/\[|\]|"//g' | head -1)
-echo "$translated"
+echo "${response}" | jq -cr '.[0] | map(.[0]) | join(" ")'


### PR DESCRIPTION
I was having the same problem as [issue 5](https://github.com/OPHoperHPO/GT-bash-client/issues/5) so I fixed it. Unfortunately this adds dependency to `jq` - is that okay?

$ ./translate.sh fr es "Bonjour. Qu'est-ce que c'est ?"                                                                                                        
Buenos dias.  Qué es ?